### PR TITLE
fix: settings now take effect immediately on cold start

### DIFF
--- a/app/src/main/kotlin/fun/fifu/stellareyes/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/fun/fifu/stellareyes/ui/settings/SettingsViewModel.kt
@@ -21,7 +21,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = false
         )
 
@@ -31,7 +31,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = false
         )
 
@@ -41,7 +41,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = false // 与 map 中的默认值一致
         )
 
@@ -59,7 +59,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = true
         )
 


### PR DESCRIPTION
- Replace SharingStarted.WhileSubscribed with SharingStarted.Eagerly for all user-preference flows so they are collected as soon as SettingsViewModel is created.
- Remove the now-redundant preloadSettings() call and its invocation in MainActivity.
- Hold a single SettingsViewModel instance in MainActivity and reuse it across all screens to guarantee consistent, zero-delay access to the latest values.

This eliminates the need to open the settings page once before options like "continuous inference" or "auto record" become active.